### PR TITLE
Add burnable LuckCoin ERC-20 contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # LuckCoin
+
+Solidity ERC-20 token with fixed supply, burnable, and no transfer taxes.
+
+## Contract
+
+The contract is located at `contracts/LuckCoin.sol` and uses OpenZeppelin's ERC20 implementation.
+
+## Build
+
+This repository does not include a build system. Install [Hardhat](https://hardhat.org/) and OpenZeppelin contracts to compile:
+
+```bash
+npm install --save-dev hardhat @openzeppelin/contracts
+npx hardhat compile
+```

--- a/contracts/LuckCoin.sol
+++ b/contracts/LuckCoin.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+
+contract LuckCoin is ERC20, ERC20Burnable {
+    uint8 private constant DECIMALS = 18;
+    uint256 private constant INITIAL_SUPPLY = 1_000_000_000 * (10 ** DECIMALS);
+
+    constructor() ERC20("LuckCoin", "LUCK") {
+        _mint(msg.sender, INITIAL_SUPPLY);
+    }
+
+    function decimals() public pure override returns (uint8) {
+        return DECIMALS;
+    }
+}


### PR DESCRIPTION
## Summary
- add `LuckCoin.sol` ERC-20 contract with fixed supply and burnable extension
- document location and build instructions in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68994dd982a4832cbf64d8971266b273