### PR TITLE
docs: clarify test-transfer usage

### DIFF
--- a/scripts/test-transfer.js
+++ b/scripts/test-transfer.js
@@ -1,10 +1,12 @@
 const { ethers } = require("hardhat");
 
 async function main() {
-  const [addr, toRaw, amountInput] = process.argv.slice(2);
+  const args = process.argv.slice(2);
+  if (args[0] === "--") args.shift();
+  const [addr, toRaw, amountInput] = args;
   if (!addr || !toRaw || !amountInput) {
     console.error(
-      "Usage: npx hardhat run scripts/test-transfer.js <tokenAddress> <to> <amount> --network <network>"
+      "Usage: npx hardhat run scripts/test-transfer.js --network <network> -- <tokenAddress> <to> <amount>"
     );
     return;
   }


### PR DESCRIPTION
## Summary
- handle argument separator in test-transfer script
- document correct Hardhat invocation

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a7c8c5c64832c9fd132e4cfe48cb4