### PR TITLE
fix: document test-transfer network flag order

### DIFF
--- a/scripts/test-transfer.js
+++ b/scripts/test-transfer.js
@@ -6,7 +6,7 @@ async function main() {
   const [addr, toRaw, amountInput] = args;
   if (!addr || !toRaw || !amountInput) {
     console.error(
-      "Usage: npx hardhat run scripts/test-transfer.js --network <network> -- <tokenAddress> <to> <amount>"
+      "Usage: npx hardhat run --network <network> scripts/test-transfer.js -- <tokenAddress> <to> <amount>"
     );
     return;
   }


### PR DESCRIPTION
## Summary
- update `scripts/test-transfer.js` usage example to place `--network` before the script path

## Testing
- `RPC_URL=http://localhost:8545 PRIVATE_KEY=0x0000000000000000000000000000000000000000000000000000000000000000 npx hardhat test` *(fails: HH502 Could not download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_689a8597ee44832c81742cfd7bcb460c